### PR TITLE
去掉swoole依赖项

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "hyperf-extension/jwt",
+    "name": "vfowo/jwt",
     "type": "library",
     "license": "MIT",
     "keywords": [

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,6 @@
     },
     "require": {
         "php": ">=8.0",
-        "ext-swoole": ">=4.5",
         "ext-json": "*",
         "ext-openssl": "*",
         "hyperf/cache": "^3.0.0",


### PR DESCRIPTION
因为swoole和swow的依赖，在使用hyperf-skeleton /swow-skeleton创建项目时就有过约束，所以此处多余。另外如果非swoole/swow项目使用这个库，纯属多余。