### PR TITLE
fix: Error on refresh jwt with custom claims

### DIFF
--- a/src/ManagerFactory.php
+++ b/src/ManagerFactory.php
@@ -41,6 +41,7 @@ class ManagerFactory
         $payloadFactory = $this->resolverPayloadFactory($claimFactory);
 
         return make(Manager::class, compact('codec', 'blacklist', 'claimFactory', 'payloadFactory'))
+            ->setPersistentClaims($this->config['persistent_claims'])
             ->setBlacklistEnabled($this->config['blacklist_enabled']);
     }
 


### PR DESCRIPTION
When I try to renew the jwt with custom claims, it gives an invalid structure error, as it generates the jwt without the persisted clains, this commit fixes this error.


the function that generates refreshtoken claims needs persistentClaim, and it is not assigned

```php
    protected function buildRefreshClaims(Payload $payload)
    {
        // Get the claims to be persisted from the payload
        $persistentClaims = Arr::only($payload->toArray(), $this->persistentClaims);

        // persist the relevant claims
        return array_merge(
            $persistentClaims,
            [
                'sub' => $payload['sub'],
                'iat' => $payload['iat'],
            ]
        );
    }
```